### PR TITLE
binder: Don't include the compat symbols on arm64 binaries

### DIFF
--- a/libs/binder/MemoryBase.cpp
+++ b/libs/binder/MemoryBase.cpp
@@ -45,8 +45,10 @@ MemoryBase::~MemoryBase()
 // ---------------------------------------------------------------------------
 }; // namespace android
 
+#ifndef __LP64__
 // Backwards compatibility for libdatabase_sqlcipher (http://b/8253769).
 extern "C" void _ZN7android10MemoryBaseC1ERKNS_2spINS_11IMemoryHeapEEEij(void*, void*, ssize_t, size_t);
 extern "C" void _ZN7android10MemoryBaseC1ERKNS_2spINS_11IMemoryHeapEEElj(void* obj, void* h, long o, unsigned int size) {
     _ZN7android10MemoryBaseC1ERKNS_2spINS_11IMemoryHeapEEEij(obj, h, o, size);
 }
+#endif


### PR DESCRIPTION
... Since they're not the same when built at 64-bit, and the likelihood
of blobs requiring this are slim to none, just remove them

Change-Id: Ib4207055a9aadeb589a92b97a000f94cae270aa3
